### PR TITLE
Implement correct tag token

### DIFF
--- a/src/tokenizer/state_transitions/end_tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/end_tag_open_state_transition.rs
@@ -3,8 +3,11 @@ use crate::errors::tokenizer_errors::{
   eof_before_tag_name_parse_error,
   invalid_first_character_of_tag_name_parse_error
 };
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn end_tag_open_state_transition(
   c: Option<char>, 
@@ -29,7 +32,7 @@ fn end_tag_open_state_transition_ascii_alpha(
   println!("End Tag Open State Ascii Alpha: '{:?}'", c);
 
   *current_state = DataState::TagNameState;
-  *current_token = Some(Token::EndTagToken("".to_string()));
+  *current_token = Some(Token::EndTagToken(TagToken::default()));
   
   return(None, true);
 }
@@ -95,7 +98,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::TagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/tokenizer/state_transitions/rawtext_end_tag_name_state_transition.rs
+++ b/src/tokenizer/state_transitions/rawtext_end_tag_name_state_transition.rs
@@ -1,5 +1,7 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token
+};
 
 pub fn rawtext_end_tag_name_state_transition(
   c: Option<char>, 
@@ -96,8 +98,8 @@ fn rawtext_end_tag_name_state_transition_ascii_upper_alpha(
   println!("RAWTEXT End Tag Name State Ascii Upper Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap().to_ascii_lowercase());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap().to_ascii_lowercase());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -113,8 +115,8 @@ fn rawtext_end_tag_name_state_transition_ascii_lower_alpha(
   println!("RAWTEXT End Tag Name State Ascii Lower Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -147,14 +149,15 @@ fn rawtext_end_tag_name_state_transition_anything_else(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::types::tokenizer_types::token_types::TagToken;
 
   #[test]
   fn test_rawtext_end_tag_name_state_transition_whitespace_appropriate() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rawtext_end_tag_name_state_transition(
@@ -167,7 +170,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::BeforeAttributeNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -175,9 +178,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_whitespace_incorrect_token() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::StartTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::StartTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -199,7 +202,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTState, current_state);
-    assert_eq!(Some(Token::StartTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -207,9 +210,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_whitespace_incorrect_tag_value() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div1".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div1")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -231,7 +234,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div1".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div1"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -239,9 +242,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_solidus() {
     const C: Option<char> = Some('/');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rawtext_end_tag_name_state_transition(
@@ -254,7 +257,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::SelfClosingStartTagState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -262,13 +265,13 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_greater_than_sign() {
     const C: Option<char> = Some('>');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
-        Token::EndTagToken("div".to_string())
+        Token::EndTagToken(TagToken::new("div"))
       ]), 
       false
     );
@@ -282,7 +285,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::DataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -290,9 +293,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_ascii_upper_alpha() {
     const C: Option<char> = Some('A');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rawtext_end_tag_name_state_transition(
@@ -305,7 +308,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("divA".to_string(), temporary_buffer);
   }
 
@@ -313,9 +316,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_ascii_lower_alpha() {
     const C: Option<char> = Some('a');
     let mut current_state: DataState = DataState::RAWTEXTEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rawtext_end_tag_name_state_transition(
@@ -328,7 +331,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("diva".to_string(), temporary_buffer);
   }
 
@@ -336,9 +339,9 @@ mod tests {
   fn test_rawtext_end_tag_name_state_transition_anything_else() {
     const C: Option<char> = Some('7');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -360,7 +363,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 }

--- a/src/tokenizer/state_transitions/rawtext_end_tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/rawtext_end_tag_open_state_transition.rs
@@ -1,5 +1,8 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn rawtext_end_tag_open_state_transition(
   c: Option<char>, 
@@ -21,7 +24,7 @@ fn rawtext_end_tag_open_state_transition_ascii_alpha(
 ) -> (Option<Vec<Token>>, bool) {
   println!("RAWTEXT End Tag Open State Solidus: '{:?}'", c);
 
-  *current_token = Some(Token::EndTagToken("".to_string()));
+  *current_token = Some(Token::EndTagToken(TagToken::default()));
   *current_state = DataState::RAWTEXTEndTagNameState;
 
   return (None, true);
@@ -63,7 +66,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RAWTEXTEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/tokenizer/state_transitions/rcdata_end_tag_name_state_transition.rs
+++ b/src/tokenizer/state_transitions/rcdata_end_tag_name_state_transition.rs
@@ -1,5 +1,7 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token
+};
 
 pub fn rcdata_end_tag_name_state_transition(
   c: Option<char>, 
@@ -96,8 +98,8 @@ fn rcdata_end_tag_name_state_transition_ascii_upper_alpha(
   println!("RCDATA End Tag Name State Ascii Upper Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap().to_ascii_lowercase());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap().to_ascii_lowercase());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -113,8 +115,8 @@ fn rcdata_end_tag_name_state_transition_ascii_lower_alpha(
   println!("RCDATA End Tag Name State Ascii Lower Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -147,14 +149,15 @@ fn rcdata_end_tag_name_state_transition_anything_else(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::types::tokenizer_types::token_types::TagToken;
 
   #[test]
   fn test_rcdata_end_tag_name_state_transition_whitespace_appropriate() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rcdata_end_tag_name_state_transition(
@@ -167,7 +170,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::BeforeAttributeNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -175,9 +178,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_whitespace_incorrect_token() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::StartTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::StartTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -199,7 +202,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDataState, current_state);
-    assert_eq!(Some(Token::StartTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -207,9 +210,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_whitespace_incorrect_tag_value() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div1".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div1")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -231,7 +234,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div1".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div1"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -239,9 +242,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_solidus() {
     const C: Option<char> = Some('/');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rcdata_end_tag_name_state_transition(
@@ -254,7 +257,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::SelfClosingStartTagState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -262,13 +265,13 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_greater_than_sign() {
     const C: Option<char> = Some('>');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
-        Token::EndTagToken("div".to_string())
+        Token::EndTagToken(TagToken::new("div"))
       ]), 
       false
     );
@@ -282,7 +285,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::DataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -290,9 +293,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_ascii_upper_alpha() {
     const C: Option<char> = Some('A');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rcdata_end_tag_name_state_transition(
@@ -305,7 +308,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDATAEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("divA".to_string(), temporary_buffer);
   }
 
@@ -313,9 +316,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_ascii_lower_alpha() {
     const C: Option<char> = Some('a');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = rcdata_end_tag_name_state_transition(
@@ -328,7 +331,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDATAEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("diva".to_string(), temporary_buffer);
   }
 
@@ -336,9 +339,9 @@ mod tests {
   fn test_rcdata_end_tag_name_state_transition_anything_else() {
     const C: Option<char> = Some('7');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -360,7 +363,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 }

--- a/src/tokenizer/state_transitions/rcdata_end_tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/rcdata_end_tag_open_state_transition.rs
@@ -1,5 +1,8 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn rcdata_end_tag_open_state_transition(
   c: Option<char>, 
@@ -21,7 +24,7 @@ fn rcdata_end_tag_open_state_transition_ascii_alpha(
 ) -> (Option<Vec<Token>>, bool) {
   println!("RCDATA End Tag Open State Ascii Alpha: '{:?}'", c);
 
-  *current_token = Some(Token::EndTagToken("".to_string()));
+  *current_token = Some(Token::EndTagToken(TagToken::default()));
   *current_state = DataState::RCDATAEndTagNameState;
   
   return (None, true);
@@ -52,14 +55,14 @@ mod tests {
   fn test_rcdata_end_tag_open_state_transition_ascii_alpha() {
     const C: Option<char> = Some('D');
     let mut current_state: DataState = DataState::RCDATAEndTagOpenState;
-    let mut current_token: Option<Token> = Some(Token::StartTagToken("g".to_string()));
+    let mut current_token: Option<Token> = Some(Token::StartTagToken(TagToken::new("g")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, true);
     let result = rcdata_end_tag_open_state_transition(C, &mut current_state, &mut current_token);
 
     assert_eq!(expected, result);
     assert_eq!(DataState::RCDATAEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/tokenizer/state_transitions/script_data_end_tag_name_state_transition.rs
+++ b/src/tokenizer/state_transitions/script_data_end_tag_name_state_transition.rs
@@ -1,5 +1,7 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token
+};
 
 pub fn script_data_end_tag_name_state_transition(
   c: Option<char>, 
@@ -96,8 +98,8 @@ fn script_data_end_tag_name_state_transition_ascii_upper_alpha(
   println!("Script Data End Tag Name State Ascii Upper Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap().to_ascii_lowercase());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap().to_ascii_lowercase());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -113,8 +115,8 @@ fn script_data_end_tag_name_state_transition_ascii_lower_alpha(
   println!("Script Data End Tag Name State Ascii Lower Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -147,14 +149,15 @@ fn script_data_end_tag_name_state_transition_anything_else(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::types::tokenizer_types::token_types::TagToken;
 
   #[test]
   fn test_script_data_end_tag_name_state_transition_whitespace_appropriate() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_end_tag_name_state_transition(
@@ -167,7 +170,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::BeforeAttributeNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -175,9 +178,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_whitespace_incorrect_token() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::StartTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::StartTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -199,7 +202,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataState, current_state);
-    assert_eq!(Some(Token::StartTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -207,9 +210,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_whitespace_incorrect_tag_value() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div1".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div1")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -231,7 +234,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div1".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div1"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -239,9 +242,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_solidus() {
     const C: Option<char> = Some('/');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_end_tag_name_state_transition(
@@ -254,7 +257,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::SelfClosingStartTagState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -262,13 +265,13 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_greater_than_sign() {
     const C: Option<char> = Some('>');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
-        Token::EndTagToken("div".to_string())
+        Token::EndTagToken(TagToken::new("div"))
       ]), 
       false
     );
@@ -282,7 +285,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::DataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -290,9 +293,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_ascii_upper_alpha() {
     const C: Option<char> = Some('A');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_end_tag_name_state_transition(
@@ -305,7 +308,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("divA".to_string(), temporary_buffer);
   }
 
@@ -313,9 +316,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_ascii_lower_alpha() {
     const C: Option<char> = Some('a');
     let mut current_state: DataState = DataState::ScriptDataEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_end_tag_name_state_transition(
@@ -328,7 +331,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("diva".to_string(), temporary_buffer);
   }
 
@@ -336,9 +339,9 @@ mod tests {
   fn test_script_data_end_tag_name_state_transition_anything_else() {
     const C: Option<char> = Some('7');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -360,7 +363,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 }

--- a/src/tokenizer/state_transitions/script_data_end_tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/script_data_end_tag_open_state_transition.rs
@@ -1,5 +1,8 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn script_data_end_tag_open_state_transition(
   c: Option<char>, 
@@ -21,7 +24,7 @@ fn script_data_end_tag_open_state_transition_ascii_alpha(
 ) -> (Option<Vec<Token>>, bool) {
   println!("Script Data End Tag Open State Ascii Alpha: '{:?}'", c);
 
-  *current_token = Some(Token::EndTagToken("".to_string()));
+  *current_token = Some(Token::EndTagToken(TagToken::default()));
   *current_state = DataState::ScriptDataEndTagNameState;
 
   return (None, true);
@@ -63,7 +66,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/tokenizer/state_transitions/script_data_escaped_end_tag_name_state_transition.rs
+++ b/src/tokenizer/state_transitions/script_data_escaped_end_tag_name_state_transition.rs
@@ -1,5 +1,7 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token
+};
 
 pub fn script_data_escaped_end_tag_name_state_transition(
   c: Option<char>, 
@@ -96,8 +98,8 @@ fn script_data_escaped_end_tag_name_state_transition_ascii_upper_alpha(
   println!("Script Data Escaped End Tag Name State Ascii Upper Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap().to_ascii_lowercase());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap().to_ascii_lowercase());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -113,8 +115,8 @@ fn script_data_escaped_end_tag_name_state_transition_ascii_lower_alpha(
   println!("Script Data Escaped End Tag Name State Ascii Lower Alpha: '{:?}'", c);
 
   // Add to the current tag token value
-  if let Some(Token::StartTagToken(ref mut tag_name)) | Some(Token::EndTagToken(ref mut tag_name)) = current_token {
-    tag_name.push(c.unwrap());
+  if let Some(Token::StartTagToken(ref mut tag_token)) | Some(Token::EndTagToken(ref mut tag_token)) = current_token {
+    tag_token.push_to_tag_name(c.unwrap());
   }
 
   temporary_buffer.push(c.unwrap());
@@ -147,14 +149,15 @@ fn script_data_escaped_end_tag_name_state_transition_anything_else(
 #[cfg(test)]
 mod tests {
   use super::*;
+  use crate::types::tokenizer_types::token_types::TagToken;
 
   #[test]
   fn test_script_data_escaped_end_tag_name_state_transition_whitespace_appropriate() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_escaped_end_tag_name_state_transition(
@@ -167,7 +170,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::BeforeAttributeNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -175,9 +178,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_whitespace_incorrect_token() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::StartTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::StartTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -199,7 +202,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedState, current_state);
-    assert_eq!(Some(Token::StartTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -207,9 +210,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_whitespace_incorrect_tag_value() {
     const C: Option<char> = Some('\t');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div1".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div1")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -231,7 +234,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div1".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div1"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -239,9 +242,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_solidus() {
     const C: Option<char> = Some('/');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_escaped_end_tag_name_state_transition(
@@ -254,7 +257,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::SelfClosingStartTagState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -262,13 +265,13 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_greater_than_sign() {
     const C: Option<char> = Some('>');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
-        Token::EndTagToken("div".to_string())
+        Token::EndTagToken(TagToken::new("div"))
       ]), 
       false
     );
@@ -282,7 +285,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::DataState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 
@@ -290,9 +293,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_ascii_upper_alpha() {
     const C: Option<char> = Some('A');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_escaped_end_tag_name_state_transition(
@@ -305,7 +308,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("divA".to_string(), temporary_buffer);
   }
 
@@ -313,9 +316,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_ascii_lower_alpha() {
     const C: Option<char> = Some('a');
     let mut current_state: DataState = DataState::ScriptDataEscapedEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::default()));
 
     let expected: (Option<Vec<Token>>, bool) = (None, false);
     let result = script_data_escaped_end_tag_name_state_transition(
@@ -328,7 +331,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("diva".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("diva"))), current_token);
     assert_eq!("diva".to_string(), temporary_buffer);
   }
 
@@ -336,9 +339,9 @@ mod tests {
   fn test_script_data_escaped_end_tag_name_state_transition_anything_else() {
     const C: Option<char> = Some('7');
     let mut current_state: DataState = DataState::RCDATAEndTagNameState;
-    let mut current_token: Option<Token> = Some(Token::EndTagToken("div".to_string()));
+    let mut current_token: Option<Token> = Some(Token::EndTagToken(TagToken::new("div")));
     let mut temporary_buffer = "div".to_string();
-    let recent_start_tag = Some(Token::StartTagToken("div".to_string()));
+    let recent_start_tag = Some(Token::StartTagToken(TagToken::new("div")));
 
     let expected: (Option<Vec<Token>>, bool) = (
       Some(vec![
@@ -360,7 +363,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedState, current_state);
-    assert_eq!(Some(Token::EndTagToken("div".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::new("div"))), current_token);
     assert_eq!("div".to_string(), temporary_buffer);
   }
 }

--- a/src/tokenizer/state_transitions/script_data_escaped_end_tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/script_data_escaped_end_tag_open_state_transition.rs
@@ -1,5 +1,8 @@
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn script_data_escaped_end_tag_open_state_transition(
   c: Option<char>, 
@@ -21,7 +24,7 @@ fn script_data_escaped_end_tag_open_state_transition_ascii_alpha(
 ) -> (Option<Vec<Token>>, bool) {
   println!("Script Data Escaped End Tag Open State Ascii Alpha: '{:?}'", c);
 
-  *current_token = Some(Token::EndTagToken("".to_string()));
+  *current_token = Some(Token::EndTagToken(TagToken::default()));
   *current_state = DataState::ScriptDataEscapedEndTagNameState;
 
   return (None, true);
@@ -63,7 +66,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::ScriptDataEscapedEndTagNameState, current_state);
-    assert_eq!(Some(Token::EndTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::EndTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/tokenizer/state_transitions/tag_open_state_transition.rs
+++ b/src/tokenizer/state_transitions/tag_open_state_transition.rs
@@ -3,8 +3,11 @@ use crate::errors::tokenizer_errors::{
   eof_before_tag_name_parse_error,
   invalid_first_character_of_tag_name_parse_error
 };
-use crate::types::tokenizer_types::data_states::DataState;
-use crate::types::tokenizer_types::tokens::Token;
+use crate::types::tokenizer_types::{
+  data_states::DataState,
+  tokens::Token,
+  token_types::TagToken
+};
 
 pub fn tag_open_state_transition(
   c: Option<char>, 
@@ -73,7 +76,7 @@ fn tag_open_state_transition_ascii_alpha(
 
   *current_state = DataState::TagNameState;
   *current_token = Some(
-    Token::StartTagToken("".to_string())
+    Token::StartTagToken(TagToken::default())
   );
   
   return (None, true);
@@ -173,7 +176,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::TagNameState, current_state);
-    assert_eq!(Some(Token::StartTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::default())), current_token);
   }
 
   #[test]
@@ -187,7 +190,7 @@ mod tests {
 
     assert_eq!(expected, result);
     assert_eq!(DataState::TagNameState, current_state);
-    assert_eq!(Some(Token::StartTagToken("".to_string())), current_token);
+    assert_eq!(Some(Token::StartTagToken(TagToken::default())), current_token);
   }
 
   #[test]

--- a/src/types/tokenizer_types/mod.rs
+++ b/src/types/tokenizer_types/mod.rs
@@ -1,2 +1,3 @@
 pub mod tokens;
 pub mod data_states;
+pub mod token_types;

--- a/src/types/tokenizer_types/token_types/attribute.rs
+++ b/src/types/tokenizer_types/token_types/attribute.rs
@@ -1,3 +1,10 @@
+use std::fmt::{
+  Display,
+  Formatter,
+  Result
+};
+
+#[derive(Debug, PartialEq, Clone)]
 pub struct Attribute {
   name: String,
   value: String,
@@ -47,3 +54,10 @@ impl Default for Attribute {
     };
   }
 }
+
+impl Display for Attribute {
+  fn fmt(&self, f: &mut Formatter) -> Result {
+    write!(f, "{:?}", self)
+  }
+}
+

--- a/src/types/tokenizer_types/token_types/attribute.rs
+++ b/src/types/tokenizer_types/token_types/attribute.rs
@@ -1,0 +1,49 @@
+pub struct Attribute {
+  name: String,
+  value: String,
+  duplicate: bool
+}
+
+impl Attribute {
+  pub fn get_name (&self) -> String {
+    return self.name.clone();
+  }
+
+  pub fn set_name (&mut self, new_name: String) {
+    self.name = new_name;
+  }
+
+  pub fn push_to_name (&mut self, c: char) {
+    self.name.push(c);
+  }
+
+  pub fn get_value (&self) -> String {
+    return self.value.clone();
+  }
+
+  pub fn set_value (&mut self, new_value: String) {
+    self.value = new_value;
+  }
+
+  pub fn push_to_value (&mut self, c: char) {
+    self.value.push(c);
+  }
+
+  pub fn is_duplicate(&self) -> bool {
+    return self.duplicate;
+  }
+
+  pub fn set_duplicate(&mut self, duplicate_value: bool) {
+    self.duplicate = duplicate_value;
+  }
+}
+
+impl Default for Attribute {
+  fn default() -> Attribute {
+    return Attribute {
+      name: "".to_string(),
+      value: "".to_string(),
+      duplicate: false
+    };
+  }
+}

--- a/src/types/tokenizer_types/token_types/mod.rs
+++ b/src/types/tokenizer_types/token_types/mod.rs
@@ -1,0 +1,5 @@
+mod tag_token;
+mod attribute;
+
+pub use tag_token::TagToken;
+pub use attribute::Attribute;

--- a/src/types/tokenizer_types/token_types/tag_token.rs
+++ b/src/types/tokenizer_types/token_types/tag_token.rs
@@ -1,0 +1,64 @@
+use super::Attribute;
+
+pub struct TagToken {
+  attributes: Vec<Attribute>,
+  tag_name: String
+}
+
+impl TagToken {
+  // Sets the tag name with a given string
+  fn set_tag_name (&mut self, new_tag_name: String) {
+    self.tag_name = new_tag_name;
+  }
+
+  // Pushes a char to the tag name
+  fn push_to_tag_name (&mut self, c: char) {
+    self.tag_name.push(c);
+  }
+
+  // Returns the current attribute
+  fn get_current_attribute (&mut self) -> Option<&mut Attribute> {
+    return self.attributes.last_mut();
+  }
+
+  // Creates a new default attribute, adds it to the list, and returns a mutable reference to it
+  fn add_new_attribute(&mut self) -> Option<&mut Attribute> {
+    self.attributes.push(Attribute::default());
+
+    return self.get_current_attribute();
+  }
+
+  // Sets the is_duplicate value for the current attribute
+  fn update_current_attribute_duplicate_flag(&mut self) -> bool {
+
+    let current_attribute_name = match self.get_current_attribute() {
+      Some(current_attribute) => current_attribute.get_name(),
+      None => return false,
+    };
+
+    // Count the number of duplicate values and if its 1 or more, there is a duplicate
+    // Start at -1 to account for checking current_attribute against current_attribute
+    let is_duplicate = self.attributes.iter()
+    .fold(-1, |num_dups, attr| {
+      if attr.get_name() == current_attribute_name {
+        return num_dups + 1;
+      }
+      return num_dups;
+    }) >= 1;
+
+    if is_duplicate {
+      self.get_current_attribute().unwrap().set_duplicate(true);
+    }
+
+    return is_duplicate;
+  }
+}
+
+impl Default for TagToken {
+  fn default() -> TagToken {
+    return TagToken {
+      attributes: vec![],
+      tag_name: "".to_string()
+    };
+  }
+}

--- a/src/types/tokenizer_types/token_types/tag_token.rs
+++ b/src/types/tokenizer_types/token_types/tag_token.rs
@@ -1,18 +1,33 @@
+use std::fmt::{
+  Display,
+  Formatter,
+  Result
+};
+
 use super::Attribute;
 
+#[derive(Debug, PartialEq, Clone)]
 pub struct TagToken {
-  attributes: Vec<Attribute>,
-  tag_name: String
+  pub attributes: Vec<Attribute>,
+  pub tag_name: String
 }
 
 impl TagToken {
+  // Create a new TagToken with a string as the tag name
+  pub fn new(s: &str) -> TagToken {
+    return TagToken {
+      attributes: vec![],
+      tag_name: s.to_string()
+    };
+  }
+
   // Sets the tag name with a given string
   fn set_tag_name (&mut self, new_tag_name: String) {
     self.tag_name = new_tag_name;
   }
 
   // Pushes a char to the tag name
-  fn push_to_tag_name (&mut self, c: char) {
+  pub fn push_to_tag_name (&mut self, c: char) {
     self.tag_name.push(c);
   }
 
@@ -60,5 +75,11 @@ impl Default for TagToken {
       attributes: vec![],
       tag_name: "".to_string()
     };
+  }
+}
+
+impl Display for TagToken {
+  fn fmt(&self, f: &mut Formatter) -> Result {
+    write!(f, "{:?}", self)
   }
 }

--- a/src/types/tokenizer_types/tokens.rs
+++ b/src/types/tokenizer_types/tokens.rs
@@ -11,9 +11,9 @@ pub enum Token {
   CharacterToken(char),
   CommentToken(String),
   DOCTYPE(),
-  EndTagToken(String),
+  EndTagToken(TagToken),
   EOFToken,
-  StartTagToken(String),
+  StartTagToken(TagToken),
 }
 
 impl Display for Token {

--- a/src/types/tokenizer_types/tokens.rs
+++ b/src/types/tokenizer_types/tokens.rs
@@ -4,6 +4,8 @@ use std::fmt::{
   Result
 };
 
+use super::token_types::TagToken ;
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Token {
   CharacterToken(char),


### PR DESCRIPTION
Previously, StartTagToken and EndTagToken used String as the enum data. This did not work for the future as it would also need to hold other data, like attribute names and values. This change makes StartTagToken and EndTagTokens use a new data type called TagToken as the enum data. This makes it much better for any future implementations that tokens will need to have.